### PR TITLE
Let AIs talk to each other

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,44 @@
+SHELL := /bin/sh
+
+VENV ?= .venv
+PYTHON := $(VENV)/bin/python
+PIP := $(PYTHON) -m pip
+OLLAMA_MODE ?= cloud
+OLLAMA_BASE_URL ?= https://ollama.com/api
+OLLAMA_MODEL ?= qwen3:30b
+
+.PHONY: setup test run ollama-check ollama-pull
+
+setup:
+	test -d "$(VENV)" || python3 -m venv "$(VENV)"
+	$(PIP) install --upgrade pip
+	$(PIP) install -r requirements.txt
+
+test:
+	$(PYTHON) -m unittest discover -s tests -v
+
+run:
+	if [ "$(OLLAMA_MODE)" = "local" ]; then $(MAKE) ollama-check; fi
+	OLLAMA_MODE="$(OLLAMA_MODE)" OLLAMA_BASE_URL="$(OLLAMA_BASE_URL)" OLLAMA_MODEL="$(OLLAMA_MODEL)" $(PYTHON) main.py
+
+ollama-check:
+	@if [ "$(OLLAMA_MODE)" != "local" ]; then \
+		echo "Skipping local Ollama check because OLLAMA_MODE=$(OLLAMA_MODE)."; \
+		exit 0; \
+	fi
+	@BASE_URL="$(OLLAMA_BASE_URL)"; \
+	case "$$BASE_URL" in \
+		*/api) TAGS_URL="$$BASE_URL/tags" ;; \
+		*) TAGS_URL="$$BASE_URL/api/tags" ;; \
+	esac; \
+	curl -fsS "$$TAGS_URL" >/dev/null || { \
+		echo "Ollama is not running at $$TAGS_URL. Start Ollama or switch to cloud mode before launching the app."; \
+		exit 1; \
+	}
+
+ollama-pull:
+	@if [ "$(OLLAMA_MODE)" != "local" ]; then \
+		echo "Skipping model pull because OLLAMA_MODE=$(OLLAMA_MODE). Cloud mode does not require a local model download."; \
+		exit 0; \
+	fi
+	ollama pull "$(OLLAMA_MODEL)"

--- a/sim/actions/__init__.py
+++ b/sim/actions/__init__.py
@@ -1,0 +1,21 @@
+from sim.actions.conversation import ConversationAction
+from sim.actions.movement import MovementAction
+from sim.actions.room_update import RoomUpdateAction
+from sim.actions.schemas import (
+	ActionContext,
+	ActionResult,
+	ConversationActionRequest,
+	MoveActionRequest,
+	RoomUpdateActionRequest,
+)
+
+__all__ = [
+	"ActionContext",
+	"ActionResult",
+	"ConversationAction",
+	"ConversationActionRequest",
+	"MoveActionRequest",
+	"MovementAction",
+	"RoomUpdateAction",
+	"RoomUpdateActionRequest",
+]

--- a/sim/actions/conversation.py
+++ b/sim/actions/conversation.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+from typing import Any
+
+from sim.agents.conversation_agent import ConversationAgent
+from sim.actions.schemas import (
+	ActionResult,
+	ConversationActionRequest,
+	TranscriptMessage,
+)
+from sim.core.database import Database
+from sim.services.llm_client import OllamaClientError
+
+
+class ConversationAction:
+	"""
+	Purpose:
+		Run a bounded back-and-forth conversation between two room occupants.
+	"""
+
+	def __init__(self, database: Database, llm_client: Any) -> None:
+		self.database = database
+		self.agent = ConversationAgent(llm_client)
+
+	def execute(self, request: ConversationActionRequest) -> ActionResult:
+		"""
+		Purpose:
+			Run one full conversation action with transcript persistence.
+
+		Inputs:
+			request: The conversation action request.
+
+		Outputs:
+			An ActionResult describing the conversation outcome.
+		"""
+		initiator = request.context.character
+		initiator_id = initiator.get("id")
+		room = request.context.current_room
+		room_id = room.get("id")
+
+		if not initiator_id or not room_id:
+			return ActionResult(
+				action_type="conversation",
+				success=False,
+				summary="Conversation skipped because the actor context is incomplete.",
+				warnings=["Missing character or room identifier."],
+			)
+
+		recipient_row = self.database.get_character(request.target_character_id)
+		if recipient_row is None:
+			return ActionResult(
+				action_type="conversation",
+				success=False,
+				summary="Conversation skipped because the target character was not found.",
+				warnings=[f"Character '{request.target_character_id}' was not found."],
+			)
+
+		recipient = dict(recipient_row)
+		if recipient["id"] == initiator_id:
+			return ActionResult(
+				action_type="conversation",
+				success=False,
+				summary="Conversation skipped because a character cannot target themselves.",
+				warnings=["Self-targeted conversation request."],
+			)
+
+		if recipient.get("current_room_id") != room_id:
+			return ActionResult(
+				action_type="conversation",
+				success=False,
+				summary="Conversation skipped because the target is no longer in the room.",
+				warnings=[f"Character '{recipient['id']}' is not in room '{room_id}'."],
+			)
+
+		conversation_id = self.database.create_conversation(
+			turn_number=request.context.turn_number,
+			room_id=room_id,
+			initiator_id=initiator_id,
+			recipient_id=recipient["id"],
+		)
+		start_event = self.database.create_event(
+			turn_number=request.context.turn_number,
+			character_id=initiator_id,
+			room_id=room_id,
+			log=(
+				f"{initiator.get('name', 'The character')} started a conversation "
+				f"with {recipient.get('name', 'another character')} in {room_id}."
+			),
+		)
+
+		transcript: list[TranscriptMessage] = []
+		speakers = [initiator, recipient]
+		ended_by = "max_turns"
+
+		for exchange_number in range(1, request.max_exchanges + 1):
+			speaker = speakers[(exchange_number - 1) % 2]
+			other = speakers[exchange_number % 2]
+
+			try:
+				reply = self.agent.generate_reply(
+					request=request,
+					speaker=speaker,
+					other=other,
+					transcript=transcript,
+					exchange_number=exchange_number,
+				)
+			except OllamaClientError as exc:
+				self.database.complete_conversation(
+					conversation_id=conversation_id,
+					exchange_count=len(transcript),
+					summary="Conversation ended early because the model response failed.",
+					status="failed",
+				)
+				return ActionResult(
+					action_type="conversation",
+					success=False,
+					summary="Conversation ended early because the model response failed.",
+					events_created=[start_event],
+					warnings=[str(exc)],
+				)
+
+			utterance = str(reply.get("utterance", "")).strip()
+			should_end = bool(reply.get("should_end", False))
+			end_reason = reply.get("end_reason")
+
+			if not utterance:
+				self.database.complete_conversation(
+					conversation_id=conversation_id,
+					exchange_count=len(transcript),
+					summary="Conversation ended early because the model response was empty.",
+					status="failed",
+				)
+				return ActionResult(
+					action_type="conversation",
+					success=False,
+					summary="Conversation ended early because the model response was empty.",
+					events_created=[start_event],
+					warnings=["Conversation model returned an empty utterance."],
+				)
+
+			transcript_message = TranscriptMessage(
+				speaker_id=speaker["id"],
+				speaker_name=speaker.get("name", "Unknown"),
+				message=utterance,
+				should_end=should_end,
+				end_reason=end_reason,
+			)
+			transcript.append(transcript_message)
+			self.database.append_conversation_message(
+				conversation_id=conversation_id,
+				speaker_id=speaker["id"],
+				exchange_number=exchange_number,
+				message=utterance,
+				should_end=should_end,
+				end_reason=end_reason,
+			)
+
+			if should_end:
+				ended_by = str(end_reason or "natural_close")
+				break
+
+		summary = self._build_summary(initiator, recipient, room_id, transcript, ended_by)
+		self.database.complete_conversation(
+			conversation_id=conversation_id,
+			exchange_count=len(transcript),
+			summary=summary,
+			status="completed",
+		)
+		summary_event = self.database.create_event(
+			turn_number=request.context.turn_number,
+			character_id=initiator_id,
+			room_id=room_id,
+			log=summary,
+		)
+		self.database.create_memory(
+			character_id=initiator_id,
+			memory_type="short_term",
+			text=self._build_memory_text(initiator, recipient, transcript),
+			source_event_id=summary_event,
+			created_turn=request.context.turn_number,
+		)
+		self.database.create_memory(
+			character_id=recipient["id"],
+			memory_type="short_term",
+			text=self._build_memory_text(recipient, initiator, transcript),
+			source_event_id=summary_event,
+			created_turn=request.context.turn_number,
+		)
+
+		return ActionResult(
+			action_type="conversation",
+			success=True,
+			summary=summary,
+			events_created=[start_event, summary_event],
+			state_changes={"conversation_id": conversation_id, "exchange_count": len(transcript)},
+		)
+
+	def _build_summary(
+		self,
+		initiator: dict[str, Any],
+		recipient: dict[str, Any],
+		room_id: str,
+		transcript: list[TranscriptMessage],
+		ended_by: str,
+	) -> str:
+		if not transcript:
+			return (
+				f"{initiator.get('name', 'A character')} tried to talk with "
+				f"{recipient.get('name', 'another character')} in {room_id}, "
+				"but the conversation never started."
+			)
+
+		last_message = transcript[-1].message
+		return (
+			f"{initiator.get('name', 'A character')} and "
+			f"{recipient.get('name', 'another character')} talked in {room_id} "
+			f"and ended with {ended_by}. Final note: {last_message}"
+		)
+
+	def _build_memory_text(
+		self,
+		owner: dict[str, Any],
+		other: dict[str, Any],
+		transcript: list[TranscriptMessage],
+	) -> str:
+		if not transcript:
+			return (
+				f"I tried to talk with {other.get('name', 'someone')}, but the "
+				"conversation did not get started."
+			)
+
+		first_message = transcript[0].message
+		return (
+			f"I talked with {other.get('name', 'someone')}. It started with: "
+			f"{first_message}"
+		)

--- a/sim/actions/movement.py
+++ b/sim/actions/movement.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from sim.actions.schemas import ActionResult, MoveActionRequest
+from sim.core.database import Database
+
+
+class MovementAction:
+	"""
+	Purpose:
+		Resolve a previously chosen room movement.
+	"""
+
+	def __init__(self, database: Database) -> None:
+		self.database = database
+
+	def execute(self, request: MoveActionRequest) -> ActionResult:
+		"""
+		Purpose:
+			Move a character to a target room when the target exists.
+
+		Inputs:
+			request: The movement action request.
+
+		Outputs:
+			An ActionResult describing what happened.
+		"""
+		character = request.context.character
+		current_room = request.context.current_room
+		character_id = character.get("id")
+		current_room_id = current_room.get("id")
+		target_room_id = request.target_room_id
+
+		if not character_id or not current_room_id:
+			return ActionResult(
+				action_type="move",
+				success=False,
+				summary="Movement skipped because the actor context is incomplete.",
+				warnings=["Missing character or room identifier."],
+			)
+
+		if target_room_id in {None, "", current_room_id}:
+			return ActionResult(
+				action_type="move",
+				success=True,
+				summary=f"{character.get('name', 'The character')} stayed in place.",
+			)
+
+		if self.database.get_character(character_id) is None:
+			return ActionResult(
+				action_type="move",
+				success=False,
+				summary="Movement skipped because the character no longer exists.",
+				warnings=[f"Character '{character_id}' was not found."],
+			)
+
+		target_room = self.database.get_room(target_room_id)
+		if target_room is None:
+			return ActionResult(
+				action_type="move",
+				success=False,
+				summary=f"{character.get('name', 'The character')} could not move.",
+				warnings=[f"Room '{target_room_id}' was not found."],
+			)
+
+		self.database.move_character(character_id, target_room_id)
+
+		source_label = current_room.get("name") or current_room_id
+		target_label = target_room["id"]
+		leave_event = self.database.create_event(
+			turn_number=request.context.turn_number,
+			character_id=character_id,
+			room_id=current_room_id,
+			log=f"{character.get('name', 'The character')} left {source_label} for {target_label}.",
+		)
+		enter_event = self.database.create_event(
+			turn_number=request.context.turn_number,
+			character_id=character_id,
+			room_id=target_room_id,
+			log=f"{character.get('name', 'The character')} entered {target_label} from {source_label}.",
+		)
+
+		return ActionResult(
+			action_type="move",
+			success=True,
+			summary=f"{character.get('name', 'The character')} moved to {target_label}.",
+			events_created=[leave_event, enter_event],
+			state_changes={"current_room_id": target_room_id},
+		)

--- a/sim/actions/room_update.py
+++ b/sim/actions/room_update.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from typing import Any
+
+from sim.agents.room_update_agent import RoomUpdateAgent
+from sim.actions.schemas import ActionResult, RoomUpdateActionRequest
+from sim.core.database import Database
+from sim.services.llm_client import OllamaClientError
+
+
+class RoomUpdateAction:
+	"""
+	Purpose:
+		Update the current room description using a prompt-driven model response.
+	"""
+
+	def __init__(self, database: Database, llm_client: Any) -> None:
+		self.database = database
+		self.agent = RoomUpdateAgent(llm_client)
+
+	def execute(self, request: RoomUpdateActionRequest) -> ActionResult:
+		"""
+		Purpose:
+			Generate and persist one room description update.
+
+		Inputs:
+			request: The room update action request.
+
+		Outputs:
+			An ActionResult describing the outcome.
+		"""
+		character = request.context.character
+		room = request.context.current_room
+		character_id = character.get("id")
+		room_id = room.get("id")
+		current_description = str(room.get("description", "")).strip()
+
+		if not character_id or not room_id:
+			return ActionResult(
+				action_type="room_update",
+				success=False,
+				summary="Room update skipped because the actor context is incomplete.",
+				warnings=["Missing character or room identifier."],
+			)
+
+		try:
+			reply = self.agent.generate_update(request)
+		except OllamaClientError as exc:
+			return ActionResult(
+				action_type="room_update",
+				success=False,
+				summary="Room update ended early because the model response failed.",
+				warnings=[str(exc)],
+			)
+
+		new_description = str(reply.get("new_description", "")).strip()
+		change_summary = str(reply.get("change_summary", "")).strip()
+
+		if not new_description:
+			return ActionResult(
+				action_type="room_update",
+				success=False,
+				summary="Room update produced no usable description.",
+				warnings=["Room update model returned an empty description."],
+			)
+
+		if new_description == current_description:
+			return ActionResult(
+				action_type="room_update",
+				success=True,
+				summary="Room description stayed the same.",
+			)
+
+		self.database.update_room_description(room_id, new_description)
+		event_id = self.database.create_event(
+			turn_number=request.context.turn_number,
+			character_id=character_id,
+			room_id=room_id,
+			log=change_summary or self._default_summary(character, room_id),
+		)
+
+		return ActionResult(
+			action_type="room_update",
+			success=True,
+			summary=change_summary or self._default_summary(character, room_id),
+			events_created=[event_id],
+			state_changes={"description": new_description},
+		)
+
+	def _default_summary(self, character: dict[str, Any], room_id: str) -> str:
+		return f"{character.get('name', 'The character')} updated the appearance of {room_id}."

--- a/sim/actions/schemas.py
+++ b/sim/actions/schemas.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+
+@dataclass(slots=True)
+class ActionContext:
+	"""
+	Purpose:
+		Capture the shared read-only context passed into one action.
+	"""
+
+	turn_number: int
+	character: dict[str, Any]
+	current_room: dict[str, Any]
+	characters_in_current_room: list[dict[str, Any]] = field(default_factory=list)
+	room_event_backlog: list[str] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class MoveActionRequest:
+	"""
+	Purpose:
+		Represent one movement action request.
+	"""
+
+	context: ActionContext
+	available_rooms: list[dict[str, Any]]
+	target_room_id: Optional[str]
+
+
+@dataclass(slots=True)
+class ConversationActionRequest:
+	"""
+	Purpose:
+		Represent one conversation action request.
+	"""
+
+	context: ActionContext
+	target_character_id: str
+	max_exchanges: int = 50
+
+
+@dataclass(slots=True)
+class RoomUpdateActionRequest:
+	"""
+	Purpose:
+		Represent one room description update request.
+	"""
+
+	context: ActionContext
+	update_intent: str
+
+
+@dataclass(slots=True)
+class TranscriptMessage:
+	"""
+	Purpose:
+		Represent one line in a conversation transcript.
+	"""
+
+	speaker_id: str
+	speaker_name: str
+	message: str
+	should_end: bool = False
+	end_reason: Optional[str] = None
+
+
+@dataclass(slots=True)
+class ActionResult:
+	"""
+	Purpose:
+		Represent the result of one resolved action.
+	"""
+
+	action_type: str
+	success: bool
+	summary: str
+	events_created: list[int] = field(default_factory=list)
+	state_changes: dict[str, Any] = field(default_factory=dict)
+	warnings: list[str] = field(default_factory=list)

--- a/sim/agents/.gitkeep
+++ b/sim/agents/.gitkeep
@@ -1,1 +1,0 @@
-Remove this file once real code is in here, this is to commit architecture to the repository

--- a/sim/agents/__init__.py
+++ b/sim/agents/__init__.py
@@ -1,0 +1,4 @@
+from sim.agents.conversation_agent import ConversationAgent
+from sim.agents.room_update_agent import RoomUpdateAgent
+
+__all__ = ["ConversationAgent", "RoomUpdateAgent"]

--- a/sim/agents/conversation_agent.py
+++ b/sim/agents/conversation_agent.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from typing import Any
+
+from sim.actions.schemas import ConversationActionRequest, TranscriptMessage
+
+
+class ConversationAgent:
+	"""
+	Purpose:
+		Own the prompt-building and structured reply generation for one speaker
+		turn within a conversation.
+	"""
+
+	def __init__(self, llm_client: Any) -> None:
+		self.llm_client = llm_client
+
+	def generate_reply(
+		self,
+		request: ConversationActionRequest,
+		speaker: dict[str, Any],
+		other: dict[str, Any],
+		transcript: list[TranscriptMessage],
+		exchange_number: int,
+	) -> dict[str, Any]:
+		"""
+		Purpose:
+			Generate one structured conversation reply.
+
+		Inputs:
+			request: The conversation action request.
+			speaker: The current speaker.
+			other: The other participant.
+			transcript: Shared conversation transcript so far.
+			exchange_number: 1-based transcript position for this reply.
+
+		Outputs:
+			A parsed structured reply dictionary.
+		"""
+		return self.llm_client.generate_structured_chat(
+			system_prompt=self._build_system_prompt(exchange_number, request.max_exchanges),
+			messages=[
+				{
+					"role": "user",
+					"content": self._build_conversation_prompt(
+						request=request,
+						speaker=speaker,
+						other=other,
+						transcript=transcript,
+					),
+				}
+			],
+			response_schema={
+				"type": "object",
+				"properties": {
+					"utterance": {"type": "string"},
+					"should_end": {"type": "boolean"},
+					"end_reason": {"type": ["string", "null"]},
+				},
+				"required": ["utterance", "should_end", "end_reason"],
+			},
+		)
+
+	def _build_system_prompt(self, exchange_number: int, max_exchanges: int) -> str:
+		if exchange_number >= max_exchanges:
+			closing_instruction = "You must wrap up this conversation now."
+		elif exchange_number >= 40:
+			closing_instruction = "Wrap up naturally and keep the reply concise."
+		elif exchange_number >= 30:
+			closing_instruction = "Start narrowing the topic toward a conclusion."
+		else:
+			closing_instruction = "Respond naturally and stay in character."
+
+		return (
+			"You are taking one turn in a character-to-character conversation inside a "
+			"simulation. Return JSON only. Keep the conversation grounded in what the "
+			"speaker can observe. "
+			f"{closing_instruction}"
+		)
+
+	def _build_conversation_prompt(
+		self,
+		request: ConversationActionRequest,
+		speaker: dict[str, Any],
+		other: dict[str, Any],
+		transcript: list[TranscriptMessage],
+	) -> str:
+		lines = [
+			f"Current room: {request.context.current_room.get('description', 'A room.')}",
+			f"Your name: {speaker.get('name', 'Unknown')}",
+			(
+				"Your internal details: "
+				f"background={speaker.get('background', '')}; "
+				f"personality={speaker.get('personality', '')}"
+			),
+			f"Other character visible details: {self._visible_character_details(other)}",
+			"Conversation transcript so far:",
+		]
+
+		if transcript:
+			lines.extend(
+				f"- {entry.speaker_name}: {entry.message}"
+				for entry in transcript
+			)
+		else:
+			lines.append("- No dialogue yet. Open the conversation naturally.")
+
+		if request.context.room_event_backlog:
+			lines.append("Recent room events:")
+			lines.extend(f"- {event}" for event in request.context.room_event_backlog)
+
+		lines.append(
+			"Return JSON with keys utterance, should_end, and end_reason."
+		)
+		return "\n".join(lines)
+
+	def _visible_character_details(self, character: dict[str, Any]) -> str:
+		visible_keys = ["physical_details", "appearance", "description"]
+		details = [str(character.get(key)).strip() for key in visible_keys if character.get(key)]
+		if details:
+			return f"{character.get('name', 'Unknown')} - {'; '.join(details)}"
+		return character.get("name", "Unknown")

--- a/sim/agents/room_update_agent.py
+++ b/sim/agents/room_update_agent.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from typing import Any
+
+from sim.actions.schemas import RoomUpdateActionRequest
+
+
+class RoomUpdateAgent:
+	"""
+	Purpose:
+		Own prompt-building and structured generation for room description updates.
+	"""
+
+	def __init__(self, llm_client: Any) -> None:
+		self.llm_client = llm_client
+
+	def generate_update(self, request: RoomUpdateActionRequest) -> dict[str, Any]:
+		"""
+		Purpose:
+			Generate one structured room update response.
+
+		Inputs:
+			request: The room update action request.
+
+		Outputs:
+			A parsed structured update dictionary.
+		"""
+		return self.llm_client.generate_structured_chat(
+			system_prompt=(
+				"You are updating the description of the current room in a "
+				"simulation. Return JSON only. Only describe changes to the "
+				"current room. Keep the room's identity stable and return a "
+				"usable replacement description."
+			),
+			messages=[
+				{
+					"role": "user",
+					"content": self._build_prompt(request),
+				}
+			],
+			response_schema={
+				"type": "object",
+				"properties": {
+					"new_description": {"type": "string"},
+					"change_summary": {"type": "string"},
+					"change_tags": {
+						"type": "array",
+						"items": {"type": "string"},
+					},
+				},
+				"required": ["new_description", "change_summary", "change_tags"],
+			},
+		)
+
+	def _build_prompt(self, request: RoomUpdateActionRequest) -> str:
+		room = request.context.current_room
+		character = request.context.character
+		lines = [
+			f"Current room id: {room.get('id')}",
+			f"Current room description: {room.get('description', 'A room.')}",
+			f"Acting character: {character.get('name', 'Unknown')}",
+			f"Update intent: {request.update_intent}",
+		]
+
+		if request.context.room_event_backlog:
+			lines.append("Recent room events:")
+			lines.extend(f"- {event}" for event in request.context.room_event_backlog)
+
+		lines.append(
+			"Return JSON with keys new_description, change_summary, and change_tags."
+		)
+		return "\n".join(lines)

--- a/sim/app.py
+++ b/sim/app.py
@@ -3,5 +3,9 @@ from sim.ui.window import Window
 
 def run_app():
   simulation = Simulation()
+  startup_warning = simulation.get_model_startup_warning()
+  if startup_warning:
+    simulation.event_log.append(startup_warning)
+    print(startup_warning)
   window = Window(simulation)
   window.run()

--- a/sim/core/database.py
+++ b/sim/core/database.py
@@ -101,11 +101,46 @@ class Database:
 		CREATE INDEX IF NOT EXISTS idx_events_turn_number
 		ON events(turn_number);
 
+		CREATE TABLE IF NOT EXISTS conversations (
+			id TEXT PRIMARY KEY,
+			turn_number INTEGER NOT NULL,
+			room_id TEXT NOT NULL,
+			initiator_id TEXT NOT NULL,
+			recipient_id TEXT NOT NULL,
+			status TEXT NOT NULL,
+			exchange_count INTEGER NOT NULL DEFAULT 0,
+			summary TEXT,
+			FOREIGN KEY (room_id) REFERENCES rooms(id),
+			FOREIGN KEY (initiator_id) REFERENCES characters(id),
+			FOREIGN KEY (recipient_id) REFERENCES characters(id)
+		);
+
+		CREATE TABLE IF NOT EXISTS conversation_messages (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			conversation_id TEXT NOT NULL,
+			speaker_id TEXT NOT NULL,
+			exchange_number INTEGER NOT NULL,
+			message TEXT NOT NULL,
+			should_end INTEGER NOT NULL DEFAULT 0,
+			end_reason TEXT,
+			FOREIGN KEY (conversation_id) REFERENCES conversations(id) ON DELETE CASCADE,
+			FOREIGN KEY (speaker_id) REFERENCES characters(id)
+		);
+
 		CREATE INDEX IF NOT EXISTS idx_memories_character_id
 		ON memories(character_id);
 
 		CREATE INDEX IF NOT EXISTS idx_memories_character_type
 		ON memories(character_id, memory_type);
+
+		CREATE INDEX IF NOT EXISTS idx_characters_current_room
+		ON characters(current_room_id);
+
+		CREATE INDEX IF NOT EXISTS idx_events_room_id
+		ON events(room_id);
+
+		CREATE INDEX IF NOT EXISTS idx_conversation_messages_conversation
+		ON conversation_messages(conversation_id, exchange_number);
 		"""
 		self.connection.executescript(schema)
 		self.connection.commit()
@@ -294,6 +329,98 @@ class Database:
 		)
 		self.connection.commit()
 
+	def get_room(self, room_id: str) -> Optional[sqlite3.Row]:
+		"""
+		Purpose:
+			Fetch a single room by its identifier.
+
+		Inputs:
+			room_id: The room identifier to fetch.
+
+		Outputs:
+			A sqlite3.Row if found, otherwise None.
+		"""
+		cursor = self.connection.execute(
+			"""
+			SELECT *
+			FROM rooms
+			WHERE id = ?
+			""",
+			(room_id,),
+		)
+		return cursor.fetchone()
+
+	def get_character(self, character_id: str) -> Optional[sqlite3.Row]:
+		"""
+		Purpose:
+			Fetch a single character by identifier.
+
+		Inputs:
+			character_id: The character identifier to fetch.
+
+		Outputs:
+			A sqlite3.Row if found, otherwise None.
+		"""
+		cursor = self.connection.execute(
+			"""
+			SELECT *
+			FROM characters
+			WHERE id = ?
+			""",
+			(character_id,),
+		)
+		return cursor.fetchone()
+
+	def get_characters_in_room(self, room_id: str) -> list[sqlite3.Row]:
+		"""
+		Purpose:
+			Fetch all characters currently assigned to a room.
+
+		Inputs:
+			room_id: The room identifier.
+
+		Outputs:
+			A list of sqlite3.Row objects.
+		"""
+		cursor = self.connection.execute(
+			"""
+			SELECT *
+			FROM characters
+			WHERE current_room_id = ?
+			ORDER BY name
+			""",
+			(room_id,),
+		)
+		return list(cursor.fetchall())
+
+	def get_recent_room_events(
+		self,
+		room_id: str,
+		limit: int = 20,
+	) -> list[sqlite3.Row]:
+		"""
+		Purpose:
+			Fetch recent events tied to a specific room.
+
+		Inputs:
+			room_id: The room identifier.
+			limit: Maximum number of events to return.
+
+		Outputs:
+			A list of sqlite3.Row objects.
+		"""
+		cursor = self.connection.execute(
+			"""
+			SELECT *
+			FROM events
+			WHERE room_id = ?
+			ORDER BY turn_number DESC, id DESC
+			LIMIT ?
+			""",
+			(room_id, limit),
+		)
+		return list(cursor.fetchall())
+
 	def create_event(
 		self,
 		turn_number: int,
@@ -441,6 +568,185 @@ class Database:
 			LIMIT ?
 			""",
 			(limit,),
+		)
+		return list(cursor.fetchall())
+
+	def create_conversation(
+		self,
+		turn_number: int,
+		room_id: str,
+		initiator_id: str,
+		recipient_id: str,
+		status: str = "active",
+		conversation_id: Optional[str] = None,
+	) -> str:
+		"""
+		Purpose:
+			Create a conversation row before transcript messages are appended.
+
+		Inputs:
+			turn_number: The current simulation turn.
+			room_id: The room where the conversation occurs.
+			initiator_id: The starting speaker.
+			recipient_id: The target speaker.
+			status: Current conversation status.
+			conversation_id: Optional custom identifier.
+
+		Outputs:
+			The conversation identifier that was inserted.
+		"""
+		if conversation_id is None:
+			conversation_id = str(uuid.uuid4())
+
+		self.connection.execute(
+			"""
+			INSERT INTO conversations (
+				id,
+				turn_number,
+				room_id,
+				initiator_id,
+				recipient_id,
+				status
+			)
+			VALUES (?, ?, ?, ?, ?, ?)
+			""",
+			(
+				conversation_id,
+				turn_number,
+				room_id,
+				initiator_id,
+				recipient_id,
+				status,
+			),
+		)
+		self.connection.commit()
+		return conversation_id
+
+	def append_conversation_message(
+		self,
+		conversation_id: str,
+		speaker_id: str,
+		exchange_number: int,
+		message: str,
+		should_end: bool = False,
+		end_reason: Optional[str] = None,
+	) -> int:
+		"""
+		Purpose:
+			Append one message to a persisted conversation transcript.
+
+		Inputs:
+			conversation_id: Identifier for the conversation.
+			speaker_id: The speaking character.
+			exchange_number: 1-based message order.
+			message: The utterance text.
+			should_end: Whether the speaker is signaling a wrap-up.
+			end_reason: Optional reason the conversation should end.
+
+		Outputs:
+			The inserted transcript row ID.
+		"""
+		cursor = self.connection.execute(
+			"""
+			INSERT INTO conversation_messages (
+				conversation_id,
+				speaker_id,
+				exchange_number,
+				message,
+				should_end,
+				end_reason
+			)
+			VALUES (?, ?, ?, ?, ?, ?)
+			""",
+			(
+				conversation_id,
+				speaker_id,
+				exchange_number,
+				message,
+				int(should_end),
+				end_reason,
+			),
+		)
+		message_id = cursor.lastrowid
+		self.connection.commit()
+
+		if message_id is None:
+			raise RuntimeError("Failed to retrieve conversation message ID.")
+
+		return message_id
+
+	def complete_conversation(
+		self,
+		conversation_id: str,
+		exchange_count: int,
+		summary: str,
+		status: str = "completed",
+	) -> None:
+		"""
+		Purpose:
+			Mark a conversation finished and persist its summary.
+
+		Inputs:
+			conversation_id: Identifier for the conversation.
+			exchange_count: Number of transcript messages stored.
+			summary: Final natural-language summary.
+			status: Final status string.
+
+		Outputs:
+			None.
+		"""
+		self.connection.execute(
+			"""
+			UPDATE conversations
+			SET status = ?,
+				exchange_count = ?,
+				summary = ?
+			WHERE id = ?
+			""",
+			(status, exchange_count, summary, conversation_id),
+		)
+		self.connection.commit()
+
+	def get_conversation(self, conversation_id: str) -> Optional[sqlite3.Row]:
+		"""
+		Purpose:
+			Fetch a single conversation record.
+
+		Inputs:
+			conversation_id: Identifier for the conversation.
+
+		Outputs:
+			A sqlite3.Row if found, otherwise None.
+		"""
+		cursor = self.connection.execute(
+			"""
+			SELECT *
+			FROM conversations
+			WHERE id = ?
+			""",
+			(conversation_id,),
+		)
+		return cursor.fetchone()
+
+	def get_conversation_messages(self, conversation_id: str) -> list[sqlite3.Row]:
+		"""
+		Purpose:
+			Fetch transcript rows for one conversation.
+
+		Inputs:
+			conversation_id: Identifier for the conversation.
+
+		Outputs:
+			A list of sqlite3.Row objects ordered by exchange number.
+		"""
+		cursor = self.connection.execute(
+			"""
+			SELECT *
+			FROM conversation_messages
+			WHERE conversation_id = ?
+			ORDER BY exchange_number
+			""",
+			(conversation_id,),
 		)
 		return list(cursor.fetchall())
 

--- a/sim/core/simulation.py
+++ b/sim/core/simulation.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass, field
+from typing import Optional
 
 from sim.core.database import Database
+from sim.services.llm_client import OllamaClient
 
 @dataclass
 class Simulation:
@@ -32,7 +34,9 @@ class Simulation:
 	# Internal timing values for ticking the simulation over time.
 	_time_accumulator: float = 0.0
 	tick_interval: float = 1.0
+	db_path: Optional[str] = None
 	database: Database = field(init=False, repr=False)
+	llm_client: OllamaClient = field(init=False, repr=False)
 
 	def __post_init__(self) -> None:
 		"""
@@ -47,8 +51,23 @@ class Simulation:
 			None. Creates the database connection and ensures the schema exists.
 		"""
 
-		self.database = Database()
+		self.database = Database(self.db_path)
 		self.database.initialize()
+		self.llm_client = OllamaClient.from_env()
+
+	def get_model_startup_warning(self) -> Optional[str]:
+		"""
+		Purpose:
+			Expose any user-facing model availability warning at startup time.
+
+		Inputs:
+			None.
+
+		Outputs:
+			A warning string when the current Ollama configuration is not ready,
+			otherwise None.
+		"""
+		return self.llm_client.get_startup_warning()
 
 	def start(self) -> None:
 		"""

--- a/sim/data/.gitkeep
+++ b/sim/data/.gitkeep
@@ -1,1 +1,0 @@
-Remove this file once real code is in here, this is to commit architecture to the repository

--- a/sim/services/__init__.py
+++ b/sim/services/__init__.py
@@ -1,0 +1,3 @@
+from sim.services.llm_client import OllamaClient, OllamaClientError
+
+__all__ = ["OllamaClient", "OllamaClientError"]

--- a/sim/services/llm_client.py
+++ b/sim/services/llm_client.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from typing import Any, Optional
+from urllib import error, request
+
+
+class OllamaClientError(RuntimeError):
+	"""
+	Purpose:
+		Represent Ollama configuration, availability, or response errors.
+	"""
+
+
+@dataclass(slots=True)
+class OllamaClient:
+	"""
+	Purpose:
+		Provide a small Ollama API client that supports both cloud and local
+		configurations with the same interface.
+	"""
+
+	mode: str = "cloud"
+	base_url: str = "https://ollama.com/api"
+	model: str = "qwen3:30b"
+	api_key: Optional[str] = None
+
+	@classmethod
+	def from_env(cls) -> "OllamaClient":
+		"""
+		Purpose:
+			Build a client from environment variables.
+
+		Inputs:
+			None.
+
+		Outputs:
+			A configured OllamaClient instance.
+		"""
+		return cls(
+			mode=os.environ.get("OLLAMA_MODE", "cloud"),
+			base_url=os.environ.get("OLLAMA_BASE_URL", "https://ollama.com/api"),
+			model=os.environ.get("OLLAMA_MODEL", "qwen3:30b"),
+			api_key=os.environ.get("OLLAMA_API_KEY"),
+		)
+
+	def normalized_base_url(self) -> str:
+		"""
+		Purpose:
+			Normalize the configured base URL so request paths can be appended
+			consistently.
+
+		Inputs:
+			None.
+
+		Outputs:
+			A base URL ending in `/api`.
+		"""
+		base_url = self.base_url.rstrip("/")
+		if base_url.endswith("/api"):
+			return base_url
+		return f"{base_url}/api"
+
+	def is_local_mode(self) -> bool:
+		"""
+		Purpose:
+			Indicate whether the client is configured for a local Ollama host.
+
+		Inputs:
+			None.
+
+		Outputs:
+			True when running in local mode, otherwise False.
+		"""
+		return self.mode.lower() == "local"
+
+	def get_startup_warning(self, timeout: float = 2.0) -> Optional[str]:
+		"""
+		Purpose:
+			Return a user-facing warning string if the current configuration is
+			not ready for model-backed actions.
+
+		Inputs:
+			timeout: Maximum request time in seconds for local availability checks.
+
+		Outputs:
+			A warning string or None when configuration looks usable.
+		"""
+		if self.is_local_mode():
+			if self.is_available(timeout=timeout):
+				return None
+			return (
+				"Ollama is not running at "
+				f"{self.normalized_base_url()}. Start Ollama or switch to cloud "
+				"mode before launching model-backed actions."
+			)
+
+		if not self.api_key:
+			return (
+				"OLLAMA_API_KEY is not set for Ollama Cloud. Add an API key or "
+				"switch to local mode before launching model-backed actions."
+			)
+
+		return None
+
+	def is_available(self, timeout: float = 2.0) -> bool:
+		"""
+		Purpose:
+			Check whether the configured Ollama host is reachable.
+
+		Inputs:
+			timeout: Maximum request time in seconds.
+
+		Outputs:
+			True if the host responded successfully, otherwise False.
+		"""
+		try:
+			self._request("GET", "/version", timeout=timeout)
+		except OllamaClientError:
+			return False
+		return True
+
+	def generate_structured_chat(
+		self,
+		system_prompt: str,
+		messages: list[dict[str, str]],
+		response_schema: dict[str, Any],
+		timeout: float = 30.0,
+	) -> dict[str, Any]:
+		"""
+		Purpose:
+			Request one non-streaming structured chat completion from Ollama.
+
+		Inputs:
+			system_prompt: High-level instruction for the model.
+			messages: Chat messages to send.
+			response_schema: JSON schema for the expected response.
+			timeout: Maximum request time in seconds.
+
+		Outputs:
+			A parsed JSON dictionary representing the model response.
+		"""
+		payload = {
+			"model": self.model,
+			"stream": False,
+			"format": response_schema,
+			"messages": [{"role": "system", "content": system_prompt}, *messages],
+			"options": {"temperature": 0},
+		}
+		response = self._request("POST", "/chat", data=payload, timeout=timeout)
+		content = response.get("message", {}).get("content")
+
+		if not content:
+			raise OllamaClientError("Ollama response did not include message content.")
+
+		try:
+			return json.loads(content)
+		except json.JSONDecodeError as exc:
+			raise OllamaClientError("Ollama returned non-JSON structured output.") from exc
+
+	def _request(
+		self,
+		method: str,
+		path: str,
+		data: Optional[dict[str, Any]] = None,
+		timeout: float = 30.0,
+	) -> dict[str, Any]:
+		"""
+		Purpose:
+			Perform one HTTP request against the configured Ollama host.
+
+		Inputs:
+			method: HTTP method.
+			path: API path beginning with `/`.
+			data: Optional JSON payload.
+			timeout: Maximum request time in seconds.
+
+		Outputs:
+			The parsed JSON response body.
+		"""
+		url = f"{self.normalized_base_url()}{path}"
+		headers = {"Content-Type": "application/json"}
+
+		if not self.is_local_mode() and self.api_key:
+			headers["Authorization"] = f"Bearer {self.api_key}"
+
+		body = None
+		if data is not None:
+			body = json.dumps(data).encode("utf-8")
+
+		http_request = request.Request(
+			url=url,
+			data=body,
+			headers=headers,
+			method=method,
+		)
+
+		try:
+			with request.urlopen(http_request, timeout=timeout) as response:
+				return json.loads(response.read().decode("utf-8"))
+		except error.HTTPError as exc:
+			message = exc.read().decode("utf-8", errors="replace")
+			raise OllamaClientError(
+				f"Ollama request failed with status {exc.code}: {message}"
+			) from exc
+		except (error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+			raise OllamaClientError(f"Ollama request failed: {exc}") from exc

--- a/tests/test_conversation_action.py
+++ b/tests/test_conversation_action.py
@@ -1,0 +1,124 @@
+import unittest
+import uuid
+from pathlib import Path
+
+from sim.actions.conversation import ConversationAction
+from sim.actions.schemas import ActionContext, ConversationActionRequest
+from sim.core.database import Database
+
+TESTS_DIR = Path(__file__).resolve().parent
+
+
+class FakeLLMClient:
+	def __init__(self, responses):
+		self.responses = list(responses)
+		self.calls = []
+
+	def generate_structured_chat(self, system_prompt, messages, response_schema, timeout=30.0):
+		self.calls.append(
+			{
+				"system_prompt": system_prompt,
+				"messages": messages,
+				"response_schema": response_schema,
+			}
+		)
+		return self.responses.pop(0)
+
+
+class TestConversationAction(unittest.TestCase):
+	def setUp(self) -> None:
+		self.db_path = TESTS_DIR / f"conversation_test_{uuid.uuid4().hex}.db"
+		self.database = Database(str(self.db_path))
+		self.database.initialize()
+
+		self.room_id = self.database.create_room(10, "A bright kitchen.", room_id="kitchen")
+		self.alice_id = self.database.create_character(
+			name="Alice",
+			background="Just moved in.",
+			personality="Warm and curious.",
+			current_room_id=self.room_id,
+			character_id="alice",
+		)
+		self.bob_id = self.database.create_character(
+			name="Bob",
+			background="A neighbor.",
+			personality="Friendly and calm.",
+			current_room_id=self.room_id,
+			character_id="bob",
+		)
+
+	def tearDown(self) -> None:
+		self.database.close()
+		self.db_path.unlink(missing_ok=True)
+
+	def test_conversation_persists_transcript_and_memories(self) -> None:
+		client = FakeLLMClient(
+			[
+				{
+					"utterance": "Hi Bob, how are you settling in next door?",
+					"should_end": False,
+					"end_reason": None,
+				},
+				{
+					"utterance": "Pretty well, thanks. I should get back to unpacking soon.",
+					"should_end": True,
+					"end_reason": "natural_close",
+				},
+			]
+		)
+		action = ConversationAction(self.database, client)
+		context = ActionContext(
+			turn_number=3,
+			character=dict(self.database.get_character(self.alice_id)),
+			current_room=dict(self.database.get_room(self.room_id)),
+			characters_in_current_room=[
+				dict(character)
+				for character in self.database.get_characters_in_room(self.room_id)
+			],
+			room_event_backlog=["Bob decorated the kitchen earlier."],
+		)
+
+		result = action.execute(
+			ConversationActionRequest(
+				context=context,
+				target_character_id=self.bob_id,
+				max_exchanges=6,
+			)
+		)
+
+		self.assertTrue(result.success)
+		self.assertEqual(len(result.events_created), 2)
+		conversation = self.database.get_conversation(result.state_changes["conversation_id"])
+		messages = self.database.get_conversation_messages(result.state_changes["conversation_id"])
+		alice_memories = self.database.get_character_memories(self.alice_id)
+		bob_memories = self.database.get_character_memories(self.bob_id)
+
+		self.assertIsNotNone(conversation)
+		self.assertEqual(conversation["exchange_count"], 2)
+		self.assertEqual(len(messages), 2)
+		self.assertEqual(messages[0]["speaker_id"], self.alice_id)
+		self.assertEqual(messages[1]["speaker_id"], self.bob_id)
+		self.assertEqual(len(alice_memories), 1)
+		self.assertEqual(len(bob_memories), 1)
+		self.assertIn("No dialogue yet", client.calls[0]["messages"][0]["content"])
+		self.assertIn("Hi Bob", client.calls[1]["messages"][0]["content"])
+
+	def test_conversation_fails_if_target_not_in_room(self) -> None:
+		self.database.move_character(self.bob_id, None)
+		client = FakeLLMClient([])
+		action = ConversationAction(self.database, client)
+		context = ActionContext(
+			turn_number=1,
+			character=dict(self.database.get_character(self.alice_id)),
+			current_room=dict(self.database.get_room(self.room_id)),
+		)
+
+		result = action.execute(
+			ConversationActionRequest(
+				context=context,
+				target_character_id=self.bob_id,
+			)
+		)
+
+		self.assertFalse(result.success)
+		self.assertEqual(result.events_created, [])

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,8 +1,10 @@
-import tempfile
 import unittest
+import uuid
 from pathlib import Path
 
 from sim.core.database import Database
+
+TESTS_DIR = Path(__file__).resolve().parent
 
 
 class TestDatabase(unittest.TestCase):
@@ -28,9 +30,10 @@ class TestDatabase(unittest.TestCase):
 		Outputs:
 			None.
 		"""
-		with tempfile.TemporaryDirectory() as temp_dir:
-			db_path = Path(temp_dir) / "test_sim.db"
-			database = Database(str(db_path))
+		db_path = TESTS_DIR / f"test_sim_{uuid.uuid4().hex}.db"
+		database = Database(str(db_path))
+
+		try:
 			database.initialize()
 
 			room_id = database.create_room(
@@ -67,17 +70,19 @@ class TestDatabase(unittest.TestCase):
 			self.assertEqual(len(events), 1)
 			self.assertEqual(memories[0]["memory_type"], "short_term")
 			self.assertEqual(events[0]["turn_number"], 1)
-
+		finally:
 			database.close()
+			db_path.unlink(missing_ok=True)
 
 	def test_upsert_and_get_all(self) -> None:
 		"""
 		Purpose:
 			Verify that upserting rooms and characters works, and that they can be retrieved.
 		"""
-		with tempfile.TemporaryDirectory() as temp_dir:
-			db_path = Path(temp_dir) / "test_sim_upsert.db"
-			database = Database(str(db_path))
+		db_path = TESTS_DIR / f"test_sim_upsert_{uuid.uuid4().hex}.db"
+		database = Database(str(db_path))
+
+		try:
 			database.initialize()
 
 			# Insert new room and character via upsert
@@ -99,8 +104,9 @@ class TestDatabase(unittest.TestCase):
 			self.assertEqual(len(rooms_updated), 1)
 			self.assertEqual(rooms_updated[0]["size"], 30)
 			self.assertEqual(rooms_updated[0]["description"], "An expanded testing room")
-
+		finally:
 			database.close()
+			db_path.unlink(missing_ok=True)
 
 
 if __name__ == "__main__":

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -1,0 +1,28 @@
+import os
+import unittest
+from unittest.mock import patch
+
+from sim.services.llm_client import OllamaClient
+
+
+class TestOllamaClient(unittest.TestCase):
+	def test_normalized_base_url_supports_with_or_without_api_suffix(self) -> None:
+		self.assertEqual(
+			OllamaClient(base_url="https://ollama.com/api").normalized_base_url(),
+			"https://ollama.com/api",
+		)
+		self.assertEqual(
+			OllamaClient(base_url="http://localhost:11434").normalized_base_url(),
+			"http://localhost:11434/api",
+		)
+
+	def test_cloud_warning_requires_api_key(self) -> None:
+		client = OllamaClient(mode="cloud", base_url="https://ollama.com/api", api_key=None)
+		self.assertIn("OLLAMA_API_KEY", client.get_startup_warning() or "")
+
+	@patch.dict(os.environ, {"OLLAMA_MODE": "cloud", "OLLAMA_BASE_URL": "https://ollama.com/api", "OLLAMA_MODEL": "qwen3:30b"}, clear=True)
+	def test_from_env_uses_cloud_defaults(self) -> None:
+		client = OllamaClient.from_env()
+		self.assertEqual(client.mode, "cloud")
+		self.assertEqual(client.base_url, "https://ollama.com/api")
+		self.assertEqual(client.model, "qwen3:30b")

--- a/tests/test_movement_action.py
+++ b/tests/test_movement_action.py
@@ -1,0 +1,78 @@
+import unittest
+import uuid
+from pathlib import Path
+
+from sim.actions.movement import MovementAction
+from sim.actions.schemas import ActionContext, MoveActionRequest
+from sim.core.database import Database
+
+TESTS_DIR = Path(__file__).resolve().parent
+
+
+class TestMovementAction(unittest.TestCase):
+	def setUp(self) -> None:
+		self.db_path = TESTS_DIR / f"movement_test_{uuid.uuid4().hex}.db"
+		self.database = Database(str(self.db_path))
+		self.database.initialize()
+
+		self.room_a = self.database.create_room(10, "Room A", room_id="room_a")
+		self.room_b = self.database.create_room(12, "Room B", room_id="room_b")
+		self.character_id = self.database.create_character(
+			name="Alice",
+			background="A traveler.",
+			personality="Curious.",
+			current_room_id=self.room_a,
+			character_id="alice",
+		)
+		self.action = MovementAction(self.database)
+
+	def tearDown(self) -> None:
+		self.database.close()
+		self.db_path.unlink(missing_ok=True)
+
+	def _context(self) -> ActionContext:
+		return ActionContext(
+			turn_number=1,
+			character=dict(self.database.get_character(self.character_id)),
+			current_room=dict(self.database.get_room(self.room_a)),
+		)
+
+	def test_move_success_updates_room_and_events(self) -> None:
+		result = self.action.execute(
+			MoveActionRequest(
+				context=self._context(),
+				available_rooms=[dict(room) for room in self.database.get_all_rooms()],
+				target_room_id=self.room_b,
+			)
+		)
+
+		self.assertTrue(result.success)
+		self.assertEqual(result.state_changes["current_room_id"], self.room_b)
+		self.assertEqual(len(result.events_created), 2)
+		self.assertEqual(self.database.get_character(self.character_id)["current_room_id"], self.room_b)
+
+	def test_stay_creates_no_events(self) -> None:
+		result = self.action.execute(
+			MoveActionRequest(
+				context=self._context(),
+				available_rooms=[dict(room) for room in self.database.get_all_rooms()],
+				target_room_id=self.room_a,
+			)
+		)
+
+		self.assertTrue(result.success)
+		self.assertEqual(result.events_created, [])
+		self.assertEqual(self.database.get_character(self.character_id)["current_room_id"], self.room_a)
+
+	def test_invalid_room_fails_safely(self) -> None:
+		result = self.action.execute(
+			MoveActionRequest(
+				context=self._context(),
+				available_rooms=[dict(room) for room in self.database.get_all_rooms()],
+				target_room_id="missing_room",
+			)
+		)
+
+		self.assertFalse(result.success)
+		self.assertEqual(result.events_created, [])
+		self.assertEqual(self.database.get_character(self.character_id)["current_room_id"], self.room_a)

--- a/tests/test_room_update_action.py
+++ b/tests/test_room_update_action.py
@@ -1,0 +1,99 @@
+import unittest
+import uuid
+from pathlib import Path
+
+from sim.actions.room_update import RoomUpdateAction
+from sim.actions.schemas import ActionContext, RoomUpdateActionRequest
+from sim.core.database import Database
+
+TESTS_DIR = Path(__file__).resolve().parent
+
+
+class FakeLLMClient:
+	def __init__(self, response):
+		self.response = response
+
+	def generate_structured_chat(self, system_prompt, messages, response_schema, timeout=30.0):
+		return self.response
+
+
+class TestRoomUpdateAction(unittest.TestCase):
+	def setUp(self) -> None:
+		self.db_path = TESTS_DIR / f"room_update_test_{uuid.uuid4().hex}.db"
+		self.database = Database(str(self.db_path))
+		self.database.initialize()
+
+		self.room_id = self.database.create_room(15, "A room full of unopened boxes.", room_id="living_room")
+		self.character_id = self.database.create_character(
+			name="Alice",
+			background="Just moved in.",
+			personality="Busy and hopeful.",
+			current_room_id=self.room_id,
+			character_id="alice",
+		)
+
+	def tearDown(self) -> None:
+		self.database.close()
+		self.db_path.unlink(missing_ok=True)
+
+	def test_room_update_changes_description_and_logs_event(self) -> None:
+		action = RoomUpdateAction(
+			self.database,
+			FakeLLMClient(
+				{
+					"new_description": (
+						"A mostly settled living room with books on the shelves and only "
+						"two boxes left near the sofa."
+					),
+					"change_summary": "Alice unpacked most of the living room.",
+					"change_tags": ["unpacked", "settled"],
+				}
+			),
+		)
+		context = ActionContext(
+			turn_number=4,
+			character=dict(self.database.get_character(self.character_id)),
+			current_room=dict(self.database.get_room(self.room_id)),
+		)
+
+		result = action.execute(
+			RoomUpdateActionRequest(
+				context=context,
+				update_intent="Unpack the living room so it looks more settled.",
+			)
+		)
+
+		self.assertTrue(result.success)
+		self.assertEqual(len(result.events_created), 1)
+		self.assertIn("mostly settled", self.database.get_room(self.room_id)["description"])
+
+	def test_empty_description_becomes_no_op_failure(self) -> None:
+		action = RoomUpdateAction(
+			self.database,
+			FakeLLMClient(
+				{
+					"new_description": "   ",
+					"change_summary": "No usable change.",
+					"change_tags": [],
+				}
+			),
+		)
+		context = ActionContext(
+			turn_number=1,
+			character=dict(self.database.get_character(self.character_id)),
+			current_room=dict(self.database.get_room(self.room_id)),
+		)
+
+		result = action.execute(
+			RoomUpdateActionRequest(
+				context=context,
+				update_intent="Do something vague.",
+			)
+		)
+
+		self.assertFalse(result.success)
+		self.assertEqual(result.events_created, [])
+		self.assertEqual(
+			self.database.get_room(self.room_id)["description"],
+			"A room full of unopened boxes.",
+		)

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -1,10 +1,19 @@
 import unittest
+import uuid
+from pathlib import Path
 from unittest.mock import patch
 from sim.core.simulation import Simulation
 
+TESTS_DIR = Path(__file__).resolve().parent
+
 class TestSimulation(unittest.TestCase):
     def setUp(self) -> None:
-        self.sim = Simulation()
+        self.db_path = TESTS_DIR / f"simulation_test_{uuid.uuid4().hex}.db"
+        self.sim = Simulation(db_path=str(self.db_path))
+
+    def tearDown(self) -> None:
+        self.sim.shutdown()
+        self.db_path.unlink(missing_ok=True)
 
     @patch('builtins.input', side_effect=['Alice', 'A curious explorer', 'Adventurous and friendly'])
     def test_create_character_success(self, mock_input):


### PR DESCRIPTION
## Summary

Connect with Ollama to start conversations between AI agents - they should talk back and forth until one decides to end the conversation (or some other stopping rule, like 50 total messages)

- After a conversation is finished, the whole conversation should be condensed and stored in short term memory for both agents

Closes #10

## Description

This PR introduces the first AI action layer for the simulation. The main goal was to make AI interactions real enough to drive the world forward, while still keeping the code simple and modular so the orchestrator can call into it later without absorbing all of the behavior itself.

The most important design decision was separating three concerns:

- action resolution
- agent prompting/decision making
- Ollama transport/configuration

The action layer is responsible for world changes like moving rooms, persisting conversations, updating room descriptions, creating events, and writing memories. The agent layer is responsible for prompt-driven character behavior, like generating one line of dialogue or proposing a room description update. The Ollama client stays as infrastructure, so cloud/local model access does not leak into every action.

For conversations, the main design goal was continuity. Both participants respond against the same shared transcript, so each reply has full context of what has already been said. The loop is bounded to prevent runaway turns, with a hard stop at 50 total messages. When the conversation ends, the full transcript is persisted, then condensed into a short-term memory for both participants. That gives the simulation a durable record of what happened without forcing later systems to parse raw dialogue out of the event log.

Another important decision was choosing prompt-driven behavior over a heavy validation system. The prompts are responsible for steering what the agents are allowed to do, while code only handles the mechanical checks that keep the program stable, like making sure a room exists, making sure a response parses, or treating malformed model output as a no-op. That keeps the implementation KISS and avoids turning this PR into a full policy engine.

For room changes, the design intentionally stays simple: room identity remains stable, but room descriptions can change over time. That gives agents meaningful influence over the environment without introducing a second room-state model or disrupting the existing room work already happening on other branches.

The Ollama setup was also designed to be practical for the team. The branch defaults to Ollama Cloud, but still supports local Ollama through configuration. `qwen3:30b` was chosen as the default model because it is a strong fit for multi-turn dialogue, role-playing, and agent-style behavior, which matches the needs of this simulation better than a coding-specialized model would.

Finally, this PR includes a simple repo workflow for setup, testing, and launch. The goal there was not to overbuild, but to make the branch easier to run and easier to demo in a CI/CD context.

## Testing

- Ran `python -m unittest discover -s tests -v`
- Verified movement success, invalid moves, and stay behavior
- Verified conversation transcript persistence, stop conditions, and short-term memory creation for both participants
- Verified room description updates and no-op behavior on malformed or empty model responses
- Verified Ollama client cloud-default configuration and startup warning behavior
- Updated tests to use isolated databases instead of touching the runtime simulation database
